### PR TITLE
Adding vscode path installed though snap

### DIFF
--- a/packages/flutter_tools/lib/src/vscode/vscode.dart
+++ b/packages/flutter_tools/lib/src/vscode/vscode.dart
@@ -191,6 +191,7 @@ class VsCode {
   static List<VsCode> _installedLinux() {
     return _findInstalled(<_VsCodeInstallLocation>[
       const _VsCodeInstallLocation('/usr/share/code', '.vscode'),
+      const _VsCodeInstallLocation('/snap/code/current', '.vscode'),
       const _VsCodeInstallLocation('/usr/share/code-insiders', '.vscode-insiders', isInsiders: true),
     ]);
   }


### PR DESCRIPTION
## Description

*Adding path to VScode directory installed through snap on Linux*

## Related Issues

VS Code installed via Snap does not appear in flutter doctor [#54358](https://github.com/flutter/flutter/issues/54358)
